### PR TITLE
Fix ActionSheet on iOS 9 with empty baseView

### DIFF
--- a/SimpleAlert/SimpleAlert.swift
+++ b/SimpleAlert/SimpleAlert.swift
@@ -360,6 +360,7 @@ private extension SimpleAlert.ContentView {
             titleSpaceConstraint.constant = 0
         }
         
+        baseView.setNeedsLayout()
         baseView.layoutIfNeeded()
         
         frame.size.height = baseView.bounds.height + (verticalSpaceConstraint.constant * 2)


### PR DESCRIPTION
iOS 8では大丈夫だったけど、iOS 9にアップデートされたタイミングに出たバグ

ActionSheetでtitle/messageかviewがない場合、contentViewがまだ表示される。

これを修正した

修正前
![simulator screen shot oct 8 2015 1 47 51 pm](https://cloud.githubusercontent.com/assets/1579644/10358375/96530ecc-6dc8-11e5-9fdd-d3392dcf8c90.png)

修正後
![simulator screen shot oct 8 2015 2 30 24 pm](https://cloud.githubusercontent.com/assets/1579644/10358379/a67884ee-6dc8-11e5-91e0-03353ae48c4e.png)
